### PR TITLE
Release v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Learn more about [our platform APIs](https://developer.thegroundwork.com/api/).
 **Production** (minified)
 
 ```
-https://cdn.thegroundwork.com/groundworkjs/1.2.0/groundwork.min.js
+https://cdn.thegroundwork.com/groundworkjs/patch/groundwork.min.js
 ```
 
 **Development** (additional logging)
 
 ```
-https://cdn.thegroundwork.com/groundworkjs/1.2.0/groundwork.js
+https://cdn.thegroundwork.com/groundworkjs/patch/groundwork.js
 ```
 
 ### Stand-alone

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groundwork.js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The Groundwork Platform JavaScript Client",
   "main": "dist/groundwork.js",
   "scripts": {


### PR DESCRIPTION
See https://github.com/thegroundwork/groundwork.js/pull/13 for more info. 

This PR fixes a slight deployment issue around cache-busting and CloudFront. 